### PR TITLE
Adding HTTPS to a couple of links

### DIFF
--- a/notice_and_comment/templates/regulations/nc-homepage.html
+++ b/notice_and_comment/templates/regulations/nc-homepage.html
@@ -203,8 +203,8 @@
           <img class="logo" src="{% static "regulations/img/about.png" %}" alt="About this tool"/>
 
           <div class="about-this-tool-info">
-            <p>This eRegulations tool was developed by <a href="http://18f.gsa.gov" target="_blank">18F <span class="cf-icon cf-icon-external-link"></span></a> (part of the <a href="http://www.gsa.gov" target="_blank">General Services Administration <span class="cf-icon cf-icon-external-link"></span></a>) in partnership with EPA.</p>
-            <p><strong>Learn more about the eRegulations platform at <a href="http://eregs.github.io" target="_blank">eregs.github.io <span class="cf-icon cf-icon-external-link"></span></a></strong></p>
+            <p>This eRegulations tool was developed by <a href="https://18f.gsa.gov" target="_blank">18F <span class="cf-icon cf-icon-external-link"></span></a> (part of the <a href="http://www.gsa.gov" target="_blank">General Services Administration <span class="cf-icon cf-icon-external-link"></span></a>) in partnership with EPA.</p>
+            <p><strong>Learn more about the eRegulations platform at <a href="https://eregs.github.io" target="_blank">eregs.github.io <span class="cf-icon cf-icon-external-link"></span></a></strong></p>
           </div>
 
         </div>


### PR DESCRIPTION
This updates a link to 18F and to the eRegs homepage to be `https://`, since they both work properly over each of them.