### PR TITLE
Add caching to home page

### DIFF
--- a/notice_and_comment/urls.py
+++ b/notice_and_comment/urls.py
@@ -5,11 +5,12 @@ from django.http import HttpResponse
 
 from regcore import urls as regcore_urls
 from regulations import urls as regsite_urls
+from regulations.url_caches import daily_cache
 from regulations.views.notice_home import NoticeHomeView
 
 urlpatterns = [
-    url(r'^$', NoticeHomeView.as_view(
-        template_name='regulations/nc-homepage.html')),
+    url(r'^$', daily_cache(NoticeHomeView.as_view(
+        template_name='regulations/nc-homepage.html'))),
     url(r'^api/', include(regcore_urls))
 ] + regsite_urls.urlpatterns
 


### PR DESCRIPTION
The home page makes a large number of API requests; without caching, it'll
spin those off for every user

Depends on eregs/regulations-site#454