### PR TITLE
Remove all homepage caching

### DIFF
--- a/notice_and_comment/nc_caches.py
+++ b/notice_and_comment/nc_caches.py
@@ -1,5 +1,0 @@
-from regulations.url_caches import DailyCacheMiddleware
-from django.utils.decorators import decorator_from_middleware_with_args
-
-homepage_non_cache = decorator_from_middleware_with_args(DailyCacheMiddleware)(
-    cache_timeout=0, cache_alias='eregs_longterm_cache')

--- a/notice_and_comment/nc_caches.py
+++ b/notice_and_comment/nc_caches.py
@@ -1,0 +1,5 @@
+from regulations.url_caches import DailyCacheMiddleware
+from django.utils.decorators import decorator_from_middleware_with_args
+
+homepage_non_cache = decorator_from_middleware_with_args(DailyCacheMiddleware)(
+    cache_timeout=0, cache_alias='eregs_longterm_cache')

--- a/notice_and_comment/urls.py
+++ b/notice_and_comment/urls.py
@@ -11,7 +11,9 @@ from regulations.views.preamble import PreambleView
 urlpatterns = [
     url(r'^$', NoticeHomeView.as_view(
         template_name='regulations/nc-homepage.html')),
-    url(r'^preamble/(?P<paragraphs>[-\w]+(/[-\w]+)*)$',
+    # The following overrides the URL set in regulations-site, to not use the
+    # daily_cache generator for the intro.
+    url(r'^preamble/(?P<paragraphs>[-\w]+/intro)$',
         PreambleView.as_view(), name='chrome_preamble'),
     url(r'^api/', include(regcore_urls))
 ] + regsite_urls.urlpatterns

--- a/notice_and_comment/urls.py
+++ b/notice_and_comment/urls.py
@@ -5,11 +5,11 @@ from django.http import HttpResponse
 
 from regcore import urls as regcore_urls
 from regulations import urls as regsite_urls
-from regulations.url_caches import daily_cache
+from nc_caches import homepage_non_cache
 from regulations.views.notice_home import NoticeHomeView
 
 urlpatterns = [
-    url(r'^$', daily_cache(NoticeHomeView.as_view(
+    url(r'^$', homepage_non_cache(NoticeHomeView.as_view(
         template_name='regulations/nc-homepage.html'))),
     url(r'^api/', include(regcore_urls))
 ] + regsite_urls.urlpatterns

--- a/notice_and_comment/urls.py
+++ b/notice_and_comment/urls.py
@@ -5,12 +5,14 @@ from django.http import HttpResponse
 
 from regcore import urls as regcore_urls
 from regulations import urls as regsite_urls
-from nc_caches import homepage_non_cache
 from regulations.views.notice_home import NoticeHomeView
+from regulations.views.preamble import PreambleView
 
 urlpatterns = [
-    url(r'^$', homepage_non_cache(NoticeHomeView.as_view(
-        template_name='regulations/nc-homepage.html'))),
+    url(r'^$', NoticeHomeView.as_view(
+        template_name='regulations/nc-homepage.html')),
+    url(r'^preamble/(?P<paragraphs>[-\w]+(/[-\w]+)*)$',
+        PreambleView.as_view(), name='chrome_preamble'),
     url(r'^api/', include(regcore_urls))
 ] + regsite_urls.urlpatterns
 

--- a/notice_and_comment/urls.py
+++ b/notice_and_comment/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
     url(r'^$', NoticeHomeView.as_view(
         template_name='regulations/nc-homepage.html')),
     # The following overrides the URL set in regulations-site, to not use the
-    # daily_cache generator for the intro.
+    # daily_cache decorator for the intro.
     url(r'^preamble/(?P<paragraphs>[-\w]+/intro)$',
         PreambleView.as_view(), name='chrome_preamble'),
     url(r'^api/', include(regcore_urls))


### PR DESCRIPTION
First-pass attempt to fix the incorrect “days remaining” display.