### PR TITLE
Update Django, pin regulations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 # regulations-core
-django==1.8.13
+django==1.8.15
 django-mptt==0.8.4
 django-haystack==2.4.1
 jsonschema==2.5.1
 six==1.10.0
--e git+https://github.com/eregs/regulations-core.git#egg=regcore
+-e git+https://github.com/eregs/regulations-core.git@2.0.0#egg=regcore
 
 # regulations-site (additional)
 boto3==1.3.1
@@ -14,7 +14,7 @@ requests==2.10.0
 requests-toolbelt==0.6.2
 django-redis==4.4.3
 markdown2==2.3.1
--e git+https://github.com/eregs/regulations-site.git#egg=regulations
+-e git+https://github.com/eregs/regulations-site.git@6.0.2#egg=regulations
 
 # cloud.gov
 celery[redis]==3.1.23


### PR DESCRIPTION
We have been using "master" for both regulations libraries. This pins both to
versions associated with the current master.

This won't ever need to be deployed in production, but best to pin now.