### PR TITLE
Cloud Foundry forward-compatibility

### DIFF
--- a/notice_and_comment/settings/prod.py
+++ b/notice_and_comment/settings/prod.py
@@ -60,7 +60,7 @@ COMMENT_DOCUMENT_ID = env.get_credential('DOCUMENT_ID')
 if HTTP_AUTH_USER and HTTP_AUTH_PASSWORD:
     API_BASE = 'http://{}:{}@localhost:{}/api/'.format(
         HTTP_AUTH_USER, HTTP_AUTH_PASSWORD,
-        os.environ.get('VCAP_APP_PORT', '8000'))
+        os.environ.get('PORT', '8000'))
 
 # Cookie settings - we don't inspect the contents of cookies, but this is good
 # practice


### PR DESCRIPTION
Per [Cloud Foundry documentation](https://docs.cloudfoundry.org/running/apps-enable-diego.html#app-code) use of `$VCAP_APP_HOST` and `$VCAP_APP_PASSWORD` are incompatible with newer (Diego-based) Cloud Foundry deployments. This change makes this repository forward compatible with the new cloud.gov environment deployment in AWS GovCloud.
