### PR TITLE
Cloud Foundry forward-compatibility

### DIFF
--- a/notice_and_comment/settings/base.py
+++ b/notice_and_comment/settings/base.py
@@ -17,7 +17,7 @@ ROOT_URLCONF = 'notice_and_comment.urls'
 
 DATABASES = REGCORE_DATABASES
 
-_port = os.environ.get('VCAP_APP_PORT', '8000')
+_port = os.environ.get('PORT', '8000')
 if HTTP_AUTH_USER and HTTP_AUTH_PASSWORD:
     API_BASE = 'http://{}:{}@localhost:{}/api/'.format(
         HTTP_AUTH_USER, HTTP_AUTH_PASSWORD, _port)


### PR DESCRIPTION
Per [Cloud Foundry documentation](https://docs.cloudfoundry.org/running/apps-enable-diego.html#app-code) use of `$VCAP_APP_HOST` and `$VCAP_APP_PASSWORD` are incompatible with newer (Diego-based) Cloud Foundry deployments. This change makes this repository forward compatible with the new cloud.gov environment deployment in AWS GovCloud.
