### PR TITLE
Cloud Foundry forward-compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You will also have to either export an environmental variable or create a
 local_settings.py file as follows:
 
 ```
-export VCAP_APP_PORT=1234
+export PORT=1234
 ```
 
 OR


### PR DESCRIPTION
Per [Cloud Foundry documentation](https://docs.cloudfoundry.org/running/apps-enable-diego.html#app-code) use of `$VCAP_APP_HOST` and `$VCAP_APP_PASSWORD` are incompatible with newer (Diego-based) Cloud Foundry deployments. This change makes this repository forward compatible with the new cloud.gov environment deployment in AWS GovCloud.
